### PR TITLE
Security Update

### DIFF
--- a/css-resource-cache-buster.js
+++ b/css-resource-cache-buster.js
@@ -8,8 +8,7 @@
   var lodash = require('lodash');
   var request = require('request');
   var through2 = require('through2');
-  var gutil = require('gulp-util');
-  var PluginError = gutil.PluginError;
+  var PluginError = require('plugin-error');
 
   var CSS_URL_MATCHER = /(url\s*\(\s*['"]?)(.*?)(['"]?\s*\))/g;
   var PLUGIN_NAME = 'gulp-css-resource-cache-buster';

--- a/css-resource-cache-buster.js
+++ b/css-resource-cache-buster.js
@@ -76,7 +76,7 @@
               .then(function(md5Map) {
                   var cssContent = cssFile.contents.toString('utf8');
                   var modifiedCssContent = replaceUrl(cssContent, md5Map);
-                  cssFile.contents = new Buffer(modifiedCssContent);
+                  cssFile.contents = Buffer.from(modifiedCssContent);
 
                   next(null, cssFile);
               })

--- a/package.json
+++ b/package.json
@@ -26,15 +26,15 @@
   },
   "homepage": "https://github.com/mixi-inc/gulp-css-resource-cache-buster",
   "devDependencies": {
-    "chai": "^2.2.0",
-    "chai-as-promised": "^4.3.0",
-    "mocha": "^2.2.1",
-    "multiline": "^1.0.2"
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
+    "mocha": "^8.2.0",
+    "multiline": "^2.0.0"
   },
   "dependencies": {
     "plugin-error": "^1.0.1",
-    "lodash": "^3.6.0",
+    "lodash": "^4.17.15",
     "request": "^2.54.0",
-    "through2": "^0.6.3"
+    "through2": "^4.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/mixi-inc/gulp-css-resource-cache-buster/issues"
   },
   "engines": {
-    "node": ">=0.12"
+    "node": ">=10.23.0"
   },
   "homepage": "https://github.com/mixi-inc/gulp-css-resource-cache-buster",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/mixi-inc/gulp-css-resource-cache-buster/issues"
   },
   "engines": {
-    "node" : ">=0.12"
+    "node": ">=0.12"
   },
   "homepage": "https://github.com/mixi-inc/gulp-css-resource-cache-buster",
   "devDependencies": {
@@ -32,7 +32,7 @@
     "multiline": "^1.0.2"
   },
   "dependencies": {
-    "gulp-util": "^3.0.4",
+    "plugin-error": "^1.0.1",
     "lodash": "^3.6.0",
     "request": "^2.54.0",
     "through2": "^0.6.3"

--- a/test/css-resource-cache-buster.js
+++ b/test/css-resource-cache-buster.js
@@ -106,7 +106,7 @@ src: url(path/to/local/file?md5-by-cache-buster=d41d8cd98f00b204e9800998ecf8427e
     return {
       isNull: lodash.constant(false),
       isStream: lodash.constant(false),
-      contents: new Buffer(content),
+      contents: Buffer.from(content),
     };
   }
 });


### PR DESCRIPTION
```
~/gulp-css-resource-cache-buster ❯❯❯ npm test

> gulp-css-resource-cache-buster@1.0.2 test /home/shinji.otsuka/gulp-css-resource-cache-buster
> mocha test



  cssResourceCacheBuster
    ✓ should replace a local URL that is in the specified URL convert table
    ✓ should replace a remote URL that is in the specified URL convert table (1584ms)
    ✓ should replace URLs that is not in the specified URL convert table (1337ms)
    ✓ should ignore URLs that is not in the specified URL convert table


  4 passing (3s)


~/gulp-css-resource-cache-buster ❯❯❯ npm audit

                       === npm audit security report ===

found 0 vulnerabilities
 in 172 scanned packages
```