### PR TITLE
Security Update

### DIFF
--- a/css-resource-cache-buster.js
+++ b/css-resource-cache-buster.js
@@ -6,7 +6,7 @@
   var crypto = require('crypto');
 
   var lodash = require('lodash');
-  var request = require('request');
+  var request = require('@cypress/request');
   var through2 = require('through2');
   var PluginError = require('plugin-error');
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "gulp-css-resource-cache-buster",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Cache buster plugin for remote/local resources specified by CSS.",
   "main": "css-resource-cache-buster.js",
   "directories": {
     "test": "test"
   },
   "scripts": {
-    "test": "mocha test"
+    "test": "mocha test --timeout 10000"
   },
   "repository": {
     "type": "git",
@@ -28,13 +28,12 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "mocha": "^8.2.0",
-    "multiline": "^2.0.0"
+    "mocha": "^10.2.0"
   },
   "dependencies": {
-    "plugin-error": "^1.0.1",
+    "@cypress/request": "^2.88.12",
     "lodash": "^4.17.15",
-    "request": "^2.54.0",
+    "plugin-error": "^2.0.1",
     "through2": "^4.0.2"
   }
 }

--- a/test/css-resource-cache-buster.js
+++ b/test/css-resource-cache-buster.js
@@ -5,7 +5,6 @@ var expect = chai.expect;
 var chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 
-var multiline = require('multiline');
 var lodash = require('lodash');
 var cssResourceCacheBuster = require('../css-resource-cache-buster');
 
@@ -58,16 +57,16 @@ describe('cssResourceCacheBuster', function() {
       'path/to/local/file': '/dev/null',
       'path/to/remote/file': 'http://devnull-as-a-service.com/dev/null',
     });
-    var cssContent = multiline(function() {/*
+    var cssContent = `
 src: url(path/to/remote/file);
 src: url(path/to/local/file);
-*/});
+`;
 
     stream.on('data', function(file) {
-      var expectedCssContent = multiline(function() {/*
+      var expectedCssContent = `
 src: url(path/to/remote/file?md5-by-cache-buster=d41d8cd98f00b204e9800998ecf8427e);
 src: url(path/to/local/file?md5-by-cache-buster=d41d8cd98f00b204e9800998ecf8427e);
-*/});
+`;
 
       expect(String(file.contents)).to.equal(expectedCssContent);
       done();


### PR DESCRIPTION
deprecated な `request` から `@cypress/request` に移行して脆弱性対応

```sh
request  *
Severity: moderate
Server-Side Request Forgery in Request - https://github.com/advisories/GHSA-p8p7-x288-28g6
Depends on vulnerable versions of tough-cookie
No fix available
node_modules/request
  gulp-css-resource-cache-buster  *
  Depends on vulnerable versions of request
  node_modules/gulp-css-resource-cache-buster

tough-cookie  <4.1.3
Severity: moderate
tough-cookie Prototype Pollution vulnerability - https://github.com/advisories/GHSA-72xf-g2v4-qvf3
No fix available
node_modules/request/node_modules/tough-cookie
```
