### PR TITLE
コアモジュール https に置き換えて http のサポートもやめる

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-css-resource-cache-buster",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Cache buster plugin for remote/local resources specified by CSS.",
   "main": "css-resource-cache-buster.js",
   "directories": {
@@ -31,7 +31,6 @@
     "mocha": "^10.2.0"
   },
   "dependencies": {
-    "@cypress/request": "^2.88.12",
     "lodash": "^4.17.15",
     "plugin-error": "^2.0.1",
     "through2": "^4.0.2"

--- a/test/css-resource-cache-buster.js
+++ b/test/css-resource-cache-buster.js
@@ -33,7 +33,7 @@ describe('cssResourceCacheBuster', function() {
 
   it('should replace a remote URL that is in the specified URL convert table', function(done) {
     var stream = cssResourceCacheBuster({
-      'path/to/remote/file': 'http://devnull-as-a-service.com/dev/null'
+      'path/to/remote/file': 'https://devnull-as-a-service.com/dev/null'
     });
 
     stream.on('data', function(file) {
@@ -55,7 +55,7 @@ describe('cssResourceCacheBuster', function() {
   it('should replace URLs that is not in the specified URL convert table', function(done) {
     var stream = cssResourceCacheBuster({
       'path/to/local/file': '/dev/null',
-      'path/to/remote/file': 'http://devnull-as-a-service.com/dev/null',
+      'path/to/remote/file': 'https://devnull-as-a-service.com/dev/null',
     });
     var cssContent = `
 src: url(path/to/remote/file);


### PR DESCRIPTION
脆弱性対応

```
# npm audit report

@cypress/request  <=2.88.12
Severity: moderate
Server-Side Request Forgery in Request - https://github.com/advisories/GHSA-p8p7-x288-28g6
fix available via `npm audit fix --force`
Will install @cypress/request@3.0.1, which is a breaking change
node_modules/@cypress/request
```

`@cypress/request` 3.0.1 にあげたとて http から https リダイレクト時にうまくいかない
パラメータ `allowInsecureRedirect` を使えば解決できるものの https から http へのリダイレクトを想定したものでその逆は違うきがするので利用をためらう．
`@cypress/request` 利用もやめて コアモジュール `https` で置き換える．ついでに http のサポートもやめる

